### PR TITLE
Fixing container versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:alpine
 
 WORKDIR /app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: postgis/postgis
+    image: ghcr.io/baosystems/postgis:latest
     environment:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
The postgis/postgis container no longer works on apple silicon and the latest migrate requires a newer version of go.